### PR TITLE
fix(lineedit): continuation on quotes

### DIFF
--- a/src/lineedit.c
+++ b/src/lineedit.c
@@ -411,6 +411,18 @@ void lineedit_cleanup(void) {
     disable_raw_mode();
 }
 
+bool inside_quote(const char *buf, size_t len) {
+    char single_quote = 0;
+    char double_quote = 0;
+    // Loop through buffer to check whether we are inside the quote
+    // If we are already inside one type of quote, then other type of quote is ignored.
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] == '\'' && !double_quote) single_quote ^= 1;
+        else if (buf[i] == '"' && !single_quote) double_quote ^= 1;
+    }
+    return single_quote || double_quote;
+}
+
 // Read a line with editing capabilities
 char *lineedit_read_line(const char *prompt) {
     static char buf[MAX_LINE_LENGTH];
@@ -464,8 +476,8 @@ char *lineedit_read_line(const char *prompt) {
 
         switch (c) {
             case KEY_ENTER:
-                // Check for line continuation
-                if (buf[len - 1] == '\\') {
+                // Check for new line escape and quotes
+                if (buf[len - 1] == '\\' || inside_quote(buf, len)) {
                     last_was_tab = 0;
                     if (len < MAX_LINE_LENGTH - 1) {
                         buf[len] = '\n';


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Continue taking input when inside the quote and enter is pressed.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" -->
Fixes #188 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] `feat` - New feature
- [x] `fix` - Bug fix
- [ ] `docs` - Documentation only
- [ ] `style` - Formatting (no code change)
- [ ] `refactor` - Code restructuring (no functional change)
- [ ] `test` - Adding or updating tests
- [ ] `chore` - Maintenance tasks

## Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (`./test.sh`)
- [ ] Compiles without warnings (`make CFLAGS="-Wall -Wextra -Werror -std=gnu99"`)
- [x] No trailing whitespace
- [x] Manual testing performed

**Manual testing details:**
<!-- Describe any manual testing you performed -->
Adding and removing quotes randomly (in between lines, quotes inside quotes etc)

## Security Considerations

<!-- Mark if applicable -->

- [ ] Uses safe string functions (`safe_strcpy`, `safe_strcat`, `safe_strlen`)
- [ ] Uses reentrant functions where applicable
- [ ] All buffers are bounds-checked
- [x] No new compiler warnings introduced
- [x] N/A - No security-relevant changes

## Documentation

<!-- Mark if applicable -->

- [ ] Updated relevant documentation in `docs/`
- [ ] Updated `README.md` (if adding major features)
- [ ] Added inline comments for complex logic
- [ ] N/A - No documentation needed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have rebased my branch on the latest `main`
- [x] My commits follow the conventional commit format
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Additional Notes

<!-- Any additional information reviewers should know -->
Tried to have two variables and check whether we are inside the quotes or not, but when editing lines keeping track of it is hard.
Example:
having line like `"ab'cdef"` (inner quote  `'`  is ignored since it is literals)
and removing the outer `"` the line becomes `ab'cdef"` (now `'` is not literal and is not closed also `"` is ignored)

---

[Contributing Guidelines](./CONTRIBUTING.md)
